### PR TITLE
listItemClassFromMetaField (fix #8)

### DIFF
--- a/lib/rex_nav.php
+++ b/lib/rex_nav.php
@@ -202,9 +202,10 @@ class rex_nav {
 				if (is_array($this->listItemClassFromCategoryId) && isset($this->listItemClassFromCategoryId[$cat->getId()])) {
 					$cssClasses .= ' ' . $this->listItemClassFromCategoryId[$cat->getId()];
 				}
-
+				
+				 
 				if ($this->listItemClassFromMetaField != '' && $cat->getValue($this->listItemClassFromMetaField) != '') {
-					$cssClasses .= ' ' . $cat->getValue($this->listItemClassFromMetaField);
+					$cssClasses .= ' ' . trim(str_replace("|", " ", $cat->getValue($this->listItemClassFromMetaField)));
 				}
 
 				// li id


### PR DESCRIPTION
fix von fietstouring
Damit das auch mit multiple Klassen funktioniert habe ich in rex_nav.php Zeile 207 durch folgendes ausgetauscht:
$cssClasses .= ' ' . trim(str_replace("|", " ", $cat->getValue($this->listItemClassFromMetaField)));